### PR TITLE
Add persistent sort menu with multiple options and direction toggle

### DIFF
--- a/Supscription/Views/Main/ContentView.swift
+++ b/Supscription/Views/Main/ContentView.swift
@@ -26,6 +26,7 @@ struct ContentView: View {
     @AppStorage("lastSelectedCategory") private var lastSelectedCategory: String?
     
     // MARK: - View
+    
     var body: some View {
         NavigationSplitView {
             sidebarView
@@ -81,7 +82,6 @@ struct ContentView: View {
                 }
             }
         }
-        
         .onChange(of: selectedSubscription) { oldValue, newValue in
             if let new = newValue {
                 lastSelectedID = new.id.uuidString
@@ -94,7 +94,6 @@ struct ContentView: View {
                 print("DEBUG - Saved lastSelectedCategory on selection: \(lastSelectedCategory ?? "nil")")
             }
         }
-
         .sheet(item: $activeSheet, content: sheetView)
     }
 }


### PR DESCRIPTION
This PR introduces advanced filtering for the content list view
- Implemented a native macOS-style sort menu using Menu + inline Pickers to match system apps like Passwords.
- Added support for sorting subscriptions by Name, Price, Billing Date, and Category.
- Included Ascending/Descending toggle in the same contextual menu.
- Used AppStorage to persist user sort preferences across app launches.
- Scroll position is restored when returning, keeping the last selected subscription visible.