### PR TITLE
Add time-based section headers when sorting by billing date

### DIFF
--- a/Supscription/Extensions/Subscription+BillingGrouping.swift
+++ b/Supscription/Extensions/Subscription+BillingGrouping.swift
@@ -1,0 +1,44 @@
+//
+//  Subscription+BillingGrouping.swift
+//  Supscription
+//
+//  Created by Ricardo Flores on 4/8/25.
+//
+
+import Foundation
+
+enum BillingSection: String, CaseIterable {
+    case overdue = "Overdue"
+    case today = "Today"
+    case next7Days = "Next 7 Days"
+    case laterThisMonth = "Later This Month"
+    case future = "Upcoming"
+    case noDate = "No Billing Date"
+}
+
+extension Array where Element == Subscription {
+    func groupedByBillingSection(reference: Date = Date()) -> [BillingSection: [Subscription]] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: reference)
+
+        return Dictionary(grouping: self) { subscription in
+            guard let billingDate = subscription.billingDate else {
+                return .noDate
+            }
+
+            if billingDate < today {
+                return .overdue
+            } else if calendar.isDateInToday(billingDate) {
+                return .today
+            } else if let next7 = calendar.date(byAdding: .day, value: 7, to: today),
+                      billingDate <= next7 {
+                return .next7Days
+            } else if calendar.isDate(billingDate, equalTo: today, toGranularity: .month) {
+                return .laterThisMonth
+            } else {
+                return .future
+            }
+        }
+    }
+}
+

--- a/Supscription/Views/Main/ContentListView.swift
+++ b/Supscription/Views/Main/ContentListView.swift
@@ -162,11 +162,40 @@ struct ContentListView: View {
     // MARK: - View Builders
     
     private var subscriptionList: some View {
-        ForEach(sortedSubscriptions, id: \.self) { subscription in
-            SubscriptionRowView(
-                subscription: subscription,
-                isSelected: selectedSubscription?.id == subscription.id
-            ).id(subscription.id)
+        let grouped = sortedSubscriptions.groupedByBillingSection()
+
+        return Group {
+            if sortOptionRawValue == SortOption.billingDate.rawValue {
+                ForEach(BillingSection.allCases, id: \.self) { section in
+                    if let subs = grouped[section], !subs.isEmpty {
+                        Section(header:
+                                    Text(section.rawValue)
+                            .font(.callout)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(.secondary)
+                            .padding(.top, 4)
+                            .textCase(nil)
+                                
+                        ) {
+                            ForEach(subs, id: \.self) { subscription in
+                                SubscriptionRowView(
+                                    subscription: subscription,
+                                    isSelected: selectedSubscription?.id == subscription.id
+                                )
+                                .id(subscription.id)
+                            }
+                        }
+                    }
+                }
+            } else {
+                ForEach(sortedSubscriptions, id: \.self) { subscription in
+                    SubscriptionRowView(
+                        subscription: subscription,
+                        isSelected: selectedSubscription?.id == subscription.id
+                    )
+                    .id(subscription.id)
+                }
+            }
         }
     }
     


### PR DESCRIPTION
Implements dynamic section headers in the subscription list when the user selects "Billing Date" as the sort option. Subscriptions are now grouped into intuitive time buckets:

- Overdue
- Today
- Next 7 Days
- Later This Month
- Upcoming
- No Billing Date