### PR TITLE
add SwiftData model layer unit tests

### DIFF
--- a/Supscription.xcodeproj/project.pbxproj
+++ b/Supscription.xcodeproj/project.pbxproj
@@ -10,9 +10,20 @@
 		133D167A2D29222600A3D7A8 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 133D16792D29222600A3D7A8 /* README.md */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		13B6B8A62F6FA83B00604F29 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 134F8A1C2D236E6B00198244 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 134F8A232D236E6B00198244;
+			remoteInfo = Supscription;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		133D16792D29222600A3D7A8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		134F8A242D236E6B00198244 /* Supscription.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Supscription.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B6B8A22F6FA83B00604F29 /* SupscriptionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SupscriptionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -34,10 +45,22 @@
 			path = Supscription;
 			sourceTree = "<group>";
 		};
+		13B6B8A32F6FA83B00604F29 /* SupscriptionTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SupscriptionTests;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		134F8A212D236E6B00198244 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		13B6B89F2F6FA83B00604F29 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -52,6 +75,7 @@
 			children = (
 				133D16792D29222600A3D7A8 /* README.md */,
 				134F8A262D236E6B00198244 /* Supscription */,
+				13B6B8A32F6FA83B00604F29 /* SupscriptionTests */,
 				134F8A252D236E6B00198244 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -60,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				134F8A242D236E6B00198244 /* Supscription.app */,
+				13B6B8A22F6FA83B00604F29 /* SupscriptionTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -89,6 +114,29 @@
 			productReference = 134F8A242D236E6B00198244 /* Supscription.app */;
 			productType = "com.apple.product-type.application";
 		};
+		13B6B8A12F6FA83B00604F29 /* SupscriptionTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B6B8AA2F6FA83B00604F29 /* Build configuration list for PBXNativeTarget "SupscriptionTests" */;
+			buildPhases = (
+				13B6B89E2F6FA83B00604F29 /* Sources */,
+				13B6B89F2F6FA83B00604F29 /* Frameworks */,
+				13B6B8A02F6FA83B00604F29 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				13B6B8A72F6FA83B00604F29 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				13B6B8A32F6FA83B00604F29 /* SupscriptionTests */,
+			);
+			name = SupscriptionTests;
+			packageProductDependencies = (
+			);
+			productName = SupscriptionTests;
+			productReference = 13B6B8A22F6FA83B00604F29 /* SupscriptionTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -96,11 +144,15 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1620;
+				LastSwiftUpdateCheck = 2630;
 				LastUpgradeCheck = 2630;
 				TargetAttributes = {
 					134F8A232D236E6B00198244 = {
 						CreatedOnToolsVersion = 16.2;
+					};
+					13B6B8A12F6FA83B00604F29 = {
+						CreatedOnToolsVersion = 26.3;
+						TestTargetID = 134F8A232D236E6B00198244;
 					};
 				};
 			};
@@ -119,6 +171,7 @@
 			projectRoot = "";
 			targets = (
 				134F8A232D236E6B00198244 /* Supscription */,
+				13B6B8A12F6FA83B00604F29 /* SupscriptionTests */,
 			);
 		};
 /* End PBXProject section */
@@ -132,6 +185,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		13B6B8A02F6FA83B00604F29 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -142,7 +202,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		13B6B89E2F6FA83B00604F29 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		13B6B8A72F6FA83B00604F29 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 134F8A232D236E6B00198244 /* Supscription */;
+			targetProxy = 13B6B8A62F6FA83B00604F29 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		134F8A312D236E6C00198244 /* Debug */ = {
@@ -337,6 +412,48 @@
 			};
 			name = Release;
 		};
+		13B6B8A82F6FA83B00604F29 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 45V9635UTT;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.richieflores.SupscriptionTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Supscription.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Supscription";
+			};
+			name = Debug;
+		};
+		13B6B8A92F6FA83B00604F29 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 45V9635UTT;
+				GENERATE_INFOPLIST_FILE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 26.2;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.richieflores.SupscriptionTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				STRING_CATALOG_GENERATE_SYMBOLS = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Supscription.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Supscription";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -354,6 +471,15 @@
 			buildConfigurations = (
 				134F8A342D236E6C00198244 /* Debug */,
 				134F8A352D236E6C00198244 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		13B6B8AA2F6FA83B00604F29 /* Build configuration list for PBXNativeTarget "SupscriptionTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B6B8A82F6FA83B00604F29 /* Debug */,
+				13B6B8A92F6FA83B00604F29 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Supscription.xcodeproj/xcshareddata/xcschemes/Supscription.xcscheme
+++ b/Supscription.xcodeproj/xcshareddata/xcschemes/Supscription.xcscheme
@@ -29,6 +29,19 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "13B6B8A12F6FA83B00604F29"
+               BuildableName = "SupscriptionTests.xctest"
+               BlueprintName = "SupscriptionTests"
+               ReferencedContainer = "container:Supscription.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/SupscriptionTests/SubscriptionModelTests.swift
+++ b/SupscriptionTests/SubscriptionModelTests.swift
@@ -1,0 +1,229 @@
+//
+//  SubscriptionModelTests.swift
+//  SupscriptionTests
+//
+//  Created by Richie Flores on 3/21/26.
+//
+
+import XCTest
+import SwiftData
+@testable import Supscription
+
+final class SubscriptionModelTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: Subscription.self, configurations: config)
+        context = ModelContext(container)
+    }
+
+    override func tearDownWithError() throws {
+        container = nil
+        context = nil
+    }
+
+    // MARK: - Test Create and Save
+
+    func testCreateAndSave() throws {
+        let sub = Subscription(
+            accountName: "Netflix",
+            category: "Streaming",
+            price: 15.99,
+            billingDate: Date(),
+            billingFrequency: BillingFrequency.monthly.rawValue,
+            autoRenew: true,
+            remindToCancel: false,
+            cancelReminderDate: nil,
+            logoName: "netflix-logo",
+            accountURL: "netflix.com",
+            lastModified: nil
+        )
+
+        context.insert(sub)
+        try context.save()
+
+        let descriptor = FetchDescriptor<Subscription>()
+        let results = try context.fetch(descriptor)
+
+        XCTAssertEqual(results.count, 1)
+
+        let fetched = try XCTUnwrap(results.first)
+        XCTAssertEqual(fetched.accountName, "Netflix")
+        XCTAssertEqual(fetched.category, "Streaming")
+        XCTAssertEqual(fetched.price, 15.99, accuracy: 0.001)
+        XCTAssertEqual(fetched.billingFrequency, "Monthly")
+        XCTAssertTrue(fetched.autoRenew)
+        XCTAssertFalse(fetched.remindToCancel)
+        XCTAssertNil(fetched.cancelReminderDate)
+        XCTAssertEqual(fetched.logoName, "netflix-logo")
+        XCTAssertEqual(fetched.accountURL, "netflix.com")
+    }
+
+    // MARK: - Test Fetch by ID
+
+    func testFetchByID() throws {
+        let sub = Subscription(
+            accountName: "Spotify",
+            category: "Music",
+            price: 10.99,
+            billingDate: nil,
+            billingFrequency: BillingFrequency.monthly.rawValue,
+            autoRenew: true,
+            remindToCancel: false,
+            cancelReminderDate: nil,
+            lastModified: nil
+        )
+
+        context.insert(sub)
+        try context.save()
+
+        let targetID = sub.id
+        let predicate = #Predicate<Subscription> { $0.id == targetID }
+        let descriptor = FetchDescriptor<Subscription>(predicate: predicate)
+        let results = try context.fetch(descriptor)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results.first?.accountName, "Spotify")
+    }
+
+    // MARK: - Test Update Field
+
+    func testUpdateField() throws {
+        let sub = Subscription(
+            accountName: "Hulu",
+            category: "Streaming",
+            price: 7.99,
+            billingDate: nil,
+            billingFrequency: BillingFrequency.monthly.rawValue,
+            autoRenew: false,
+            remindToCancel: false,
+            cancelReminderDate: nil,
+            lastModified: nil
+        )
+
+        context.insert(sub)
+        try context.save()
+
+        sub.price = 17.99
+        sub.accountName = "Hulu Premium"
+        sub.lastModified = Date()
+        try context.save()
+
+        let targetID = sub.id
+        let predicate = #Predicate<Subscription> { $0.id == targetID }
+        let descriptor = FetchDescriptor<Subscription>(predicate: predicate)
+        let results = try context.fetch(descriptor)
+
+        let fetched = try XCTUnwrap(results.first)
+        XCTAssertEqual(fetched.accountName, "Hulu Premium")
+        XCTAssertEqual(fetched.price, 17.99, accuracy: 0.001)
+    }
+
+    // MARK: - Test Delete
+
+    func testDelete() throws {
+        let sub = Subscription(
+            accountName: "Apple TV+",
+            category: "Streaming",
+            price: 9.99,
+            billingDate: nil,
+            billingFrequency: BillingFrequency.monthly.rawValue,
+            autoRenew: true,
+            remindToCancel: false,
+            cancelReminderDate: nil,
+            lastModified: nil
+        )
+
+        context.insert(sub)
+        try context.save()
+
+        let beforeDelete = try context.fetch(FetchDescriptor<Subscription>())
+        XCTAssertEqual(beforeDelete.count, 1)
+
+        context.delete(sub)
+        try context.save()
+
+        let afterDelete = try context.fetch(FetchDescriptor<Subscription>())
+        XCTAssertEqual(afterDelete.count, 0)
+    }
+
+    // MARK: - Test Create with Nil Optionals
+
+    func testCreateWithNilOptionals() throws {
+        let sub = Subscription(
+            accountName: "Mystery Service",
+            category: nil,
+            price: 0.0,
+            billingDate: nil,
+            billingFrequency: BillingFrequency.none.rawValue,
+            autoRenew: true,
+            remindToCancel: false,
+            cancelReminderDate: nil,
+            logoName: nil,
+            accountURL: nil,
+            lastModified: nil
+        )
+
+        context.insert(sub)
+        try context.save()
+
+        let results = try context.fetch(FetchDescriptor<Subscription>())
+        let fetched = try XCTUnwrap(results.first)
+
+        XCTAssertEqual(fetched.accountName, "Mystery Service")
+        XCTAssertNil(fetched.category)
+        XCTAssertNil(fetched.logoName)
+        XCTAssertNil(fetched.accountURL)
+        XCTAssertNil(fetched.billingDate)
+        XCTAssertNil(fetched.cancelReminderDate)
+        XCTAssertEqual(fetched.price, 0.0, accuracy: 0.001)
+        XCTAssertTrue(fetched.autoRenew)
+        XCTAssertFalse(fetched.remindToCancel)
+    }
+
+    // MARK: - Test Duplicate Name Allowed at Model Level
+
+    func testDuplicateNameAllowedAtModelLevel() throws {
+        let sub1 = Subscription(
+            accountName: "Netflix",
+            category: "Streaming",
+            price: 15.99,
+            billingDate: nil,
+            billingFrequency: BillingFrequency.monthly.rawValue,
+            autoRenew: true,
+            remindToCancel: false,
+            cancelReminderDate: nil,
+            lastModified: nil
+        )
+
+        let sub2 = Subscription(
+            accountName: "Netflix",
+            category: "Entertainment",
+            price: 22.99,
+            billingDate: nil,
+            billingFrequency: BillingFrequency.monthly.rawValue,
+            autoRenew: false,
+            remindToCancel: true,
+            cancelReminderDate: Date(),
+            lastModified: nil
+        )
+
+        context.insert(sub1)
+        context.insert(sub2)
+        try context.save()
+
+        let results = try context.fetch(FetchDescriptor<Subscription>())
+
+        // Both save — duplicate detection is view-level, not model-level
+        XCTAssertEqual(results.count, 2)
+
+        let names = results.map(\.accountName)
+        XCTAssertEqual(names.filter { $0 == "Netflix" }.count, 2)
+
+        // Verify they have distinct IDs
+        XCTAssertNotEqual(sub1.id, sub2.id)
+    }
+}


### PR DESCRIPTION
Adds unit tests for the Subscription SwiftData model covering 
create, fetch, update, delete, nil optionals, and duplicate 
name behavior.

Closes #38 