### PR TITLE
Refactor iOS dashboard interactions and previews

### DIFF
--- a/Shared/Extensions/Date+Formatting.swift
+++ b/Shared/Extensions/Date+Formatting.swift
@@ -13,11 +13,11 @@ extension Date {
         formatter.dateStyle = .medium
         return formatter.string(from: self)
     }
-    
+
     // Returns "Today", "Tomorrow", or "MMM d" (e.g. "Apr 9")
     func formattedShortFriendly() -> String {
         let calendar = Calendar.current
-        
+
         if calendar.isDateInToday(self) {
             return "Today"
         } else if calendar.isDateInTomorrow(self) {
@@ -28,7 +28,7 @@ extension Date {
             return formatter.string(from: self)
         }
     }
-    
+
     // Returns the same date with time normalized to 9:00 AM by default
     func normalizedToMorning(hour: Int = 9) -> Date {
         let calendar = Calendar.current

--- a/Shared/Utils/PreviewContainer.swift
+++ b/Shared/Utils/PreviewContainer.swift
@@ -20,4 +20,11 @@ let previewContainer: ModelContainer = {
 
     return container
 }()
+
+@MainActor
+let emptyPreviewContainer: ModelContainer = {
+    let schema = Schema([Subscription.self])
+    let config = ModelConfiguration(isStoredInMemoryOnly: true)
+    return try! ModelContainer(for: schema, configurations: [config])
+}()
 #endif

--- a/Shared/ViewModels/DashboardViewModel.swift
+++ b/Shared/ViewModels/DashboardViewModel.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Combine
 
 // MARK: - Chart Data Models
 
@@ -24,7 +25,9 @@ struct CategoryDataPoint: Identifiable {
 // MARK: - ViewModel
 
 class DashboardViewModel: ObservableObject {
-    let subscriptions: [Subscription]
+    var subscriptions: [Subscription] {
+        didSet { objectWillChange.send() }
+    }
 
     @Published var isExpanded: Bool = false
 
@@ -124,12 +127,6 @@ class DashboardViewModel: ObservableObject {
         case .none:
             return false
         }
-    }
-
-    var currentMonthAbbrev: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMM"
-        return formatter.string(from: Date())
     }
 
     // MARK: - Category Breakdown

--- a/Shared/ViewModels/DashboardViewModel.swift
+++ b/Shared/ViewModels/DashboardViewModel.swift
@@ -12,6 +12,7 @@ import Combine
 
 struct MonthlyDataPoint: Identifiable {
     let id = UUID()
+    let date: Date
     let month: String
     let amount: Double
 }
@@ -91,42 +92,93 @@ class DashboardViewModel: ObservableObject {
         for offset in stride(from: -5, through: 0, by: 1) {
             guard let monthDate = calendar.date(byAdding: .month, value: offset, to: now) else { continue }
             let monthLabel = formatter.string(from: monthDate)
-            let monthComponents = calendar.dateComponents([.year, .month], from: monthDate)
-
-            var total: Double = 0
-            for sub in subscriptions {
-                guard let billingDate = sub.billingDate,
-                      let frequency = BillingFrequency(rawValue: sub.billingFrequency),
-                      frequency != .none else { continue }
-
-                if hasBillingEvent(billingDate: billingDate, frequency: frequency, inMonth: monthComponents, calendar: calendar) {
-                    total += sub.price
-                }
+            let total = subscriptions.reduce(0) { partialResult, subscription in
+                partialResult + monthlySpend(for: subscription, inMonthContaining: monthDate, calendar: calendar)
             }
 
-            result.append(MonthlyDataPoint(month: monthLabel, amount: total))
+            result.append(MonthlyDataPoint(date: monthDate, month: monthLabel, amount: total))
         }
 
         return result
     }
 
-    private func hasBillingEvent(billingDate: Date, frequency: BillingFrequency, inMonth target: DateComponents, calendar: Calendar) -> Bool {
-        guard let targetYear = target.year, let targetMonth = target.month else { return false }
-
-        let billingComponents = calendar.dateComponents([.year, .month], from: billingDate)
-        guard let billingYear = billingComponents.year, let billingMonth = billingComponents.month else { return false }
-
-        switch frequency {
-        case .daily, .weekly, .monthly:
-            return true
-        case .quarterly:
-            let diff = (targetYear * 12 + targetMonth) - (billingYear * 12 + billingMonth)
-            return diff >= 0 && diff % 3 == 0
-        case .yearly:
-            return targetMonth == billingMonth
-        case .none:
-            return false
+    private func monthlySpend(for subscription: Subscription, inMonthContaining monthDate: Date, calendar: Calendar) -> Double {
+        guard let billingDate = subscription.billingDate,
+              let frequency = BillingFrequency(rawValue: subscription.billingFrequency),
+              frequency != .none,
+              let monthInterval = calendar.dateInterval(of: .month, for: monthDate) else {
+            return 0
         }
+
+        let occurrences = occurrenceCount(
+            startingAt: billingDate,
+            frequency: frequency,
+            in: monthInterval,
+            calendar: calendar
+        )
+
+        return Double(occurrences) * subscription.price
+    }
+
+    private func occurrenceCount(
+        startingAt billingDate: Date,
+        frequency: BillingFrequency,
+        in interval: DateInterval,
+        calendar: Calendar
+    ) -> Int {
+        if billingDate >= interval.end {
+            return 0
+        }
+
+        var occurrence = billingDate
+        while occurrence < interval.start {
+            let next = nextOccurrence(after: occurrence, frequency: frequency, calendar: calendar)
+            if next <= occurrence { return 0 }
+            occurrence = next
+        }
+
+        var count = 0
+        while occurrence < interval.end {
+            if occurrence >= interval.start {
+                count += 1
+            }
+
+            let next = nextOccurrence(after: occurrence, frequency: frequency, calendar: calendar)
+            if next <= occurrence { break }
+            occurrence = next
+        }
+
+        return count
+    }
+
+    private func nextOccurrence(after date: Date, frequency: BillingFrequency, calendar: Calendar) -> Date {
+        switch frequency {
+        case .daily:
+            return calendar.date(byAdding: .day, value: 1, to: date) ?? date
+        case .weekly:
+            return calendar.date(byAdding: .weekOfYear, value: 1, to: date) ?? date
+        case .monthly:
+            return calendar.date(byAdding: .month, value: 1, to: date) ?? date
+        case .quarterly:
+            return calendar.date(byAdding: .month, value: 3, to: date) ?? date
+        case .yearly:
+            return calendar.date(byAdding: .year, value: 1, to: date) ?? date
+        case .none:
+            return date
+        }
+    }
+
+    var monthlyTrendAccessibilitySummary: String {
+        guard let latest = monthlySeries.last else { return "No spending data available." }
+
+        let peak = monthlySeries.max { lhs, rhs in
+            lhs.amount < rhs.amount
+        }
+
+        let latestSummary = "\(latest.month) spending is \(formattedCurrency(latest.amount))."
+        guard let peak else { return latestSummary }
+
+        return "\(latestSummary) Highest month is \(peak.month) at \(formattedCurrency(peak.amount))."
     }
 
     // MARK: - Category Breakdown
@@ -185,5 +237,13 @@ class DashboardViewModel: ObservableObject {
         formatter.numberStyle = .currency
         formatter.locale = Locale.current
         return formatter.string(from: NSNumber(value: value)) ?? "$0.00"
+    }
+
+    func formattedAxisCurrency(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.locale = Locale.current
+        formatter.maximumFractionDigits = 0
+        return formatter.string(from: NSNumber(value: value)) ?? formattedCurrency(value)
     }
 }

--- a/Supscription iOS/Views/ContentView.swift
+++ b/Supscription iOS/Views/ContentView.swift
@@ -26,7 +26,12 @@ struct ContentView: View {
     }
 }
 
-#Preview {
+#Preview("Content Filled") {
     ContentView()
         .modelContainer(previewContainer)
+}
+
+#Preview("Content Empty") {
+    ContentView()
+        .modelContainer(emptyPreviewContainer)
 }

--- a/Supscription iOS/Views/Dashboard/ScoreCardView.swift
+++ b/Supscription iOS/Views/Dashboard/ScoreCardView.swift
@@ -1,0 +1,52 @@
+//
+//  ScoreCardView.swift
+//  Supscription iOS
+//
+//  Created by Richie Flores on 4/10/26.
+//
+
+import SwiftUI
+
+struct ScoreCardView: View {
+    let title: String
+    let value: String
+    let subtitle: String
+    let systemImage: String
+    let cardColor: Color
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Image(systemName: systemImage)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.white)
+                .frame(width: 34, height: 34)
+                .background(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .fill(cardColor)
+                )
+
+            Text(value)
+                .font(.title2.weight(.bold))
+                .foregroundStyle(.white)
+                .minimumScaleFactor(0.7)
+                .lineLimit(1)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.white.opacity(0.8))
+
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.55))
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(cardColor.gradient)
+        )
+    }
+}

--- a/Supscription iOS/Views/Dashboard/ScoreCardView.swift
+++ b/Supscription iOS/Views/Dashboard/ScoreCardView.swift
@@ -48,5 +48,20 @@ struct ScoreCardView: View {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .fill(cardColor.gradient)
         )
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(title)
+        .accessibilityValue("\(value). \(subtitle)")
     }
+}
+
+#Preview("Score Card") {
+    ScoreCardView(
+        title: "Monthly Spend",
+        value: "$186.42",
+        subtitle: "14 subscriptions",
+        systemImage: "creditcard.fill",
+        cardColor: .blue
+    )
+    .padding()
+    .background(Color(.systemGroupedBackground))
 }

--- a/Supscription iOS/Views/Dashboard/UpcomingRenewalRow.swift
+++ b/Supscription iOS/Views/Dashboard/UpcomingRenewalRow.swift
@@ -1,0 +1,120 @@
+//
+//  UpcomingRenewalRow.swift
+//  Supscription iOS
+//
+//  Created by Richie Flores on 4/10/26.
+//
+
+import SwiftUI
+
+struct UpcomingRenewalRow: View {
+    let subscription: Subscription
+
+    var body: some View {
+        HStack(spacing: 12) {
+            subscriptionIcon
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(subscription.accountName)
+                    .font(.subheadline.weight(.medium))
+
+                if let category = subscription.category,
+                   !category.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    Text(category)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(subscription.price, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
+                    .font(.subheadline.weight(.semibold))
+
+                urgencyBadge
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    // MARK: - Logo / Icon
+
+    @ViewBuilder
+    private var subscriptionIcon: some View {
+        if let logoName = subscription.logoName, !logoName.isEmpty,
+           let uiImage = loadLogoImage(named: logoName) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 34, height: 34)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+        } else {
+            ZStack {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(urgencyColor.opacity(0.12))
+                    .frame(width: 34, height: 34)
+                Text(subscription.accountName.prefix(1).uppercased())
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(urgencyColor)
+            }
+        }
+    }
+
+    // MARK: - Urgency Badge
+
+    private var urgencyBadge: some View {
+        Text(urgencyLabel)
+            .font(.caption2.weight(.medium))
+            .foregroundStyle(urgencyColor)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(
+                Capsule()
+                    .fill(urgencyColor.opacity(0.12))
+            )
+    }
+
+    // MARK: - Urgency Helpers
+
+    private var daysUntilBilling: Int? {
+        guard let date = subscription.nextBillingDate else { return nil }
+        return Calendar.current.dateComponents(
+            [.day],
+            from: Calendar.current.startOfDay(for: Date()),
+            to: Calendar.current.startOfDay(for: date)
+        ).day
+    }
+
+    private var urgencyLabel: String {
+        guard let days = daysUntilBilling else { return "" }
+        switch days {
+        case ...0:    return "Today"
+        case 1:       return "Tomorrow"
+        case 2...7:   return "In \(days) days"
+        default:
+            return subscription.nextBillingDate?.formattedShortFriendly() ?? ""
+        }
+    }
+
+    private var urgencyColor: Color {
+        guard let days = daysUntilBilling else { return .blue }
+        switch days {
+        case ...0:    return .red
+        case 1...7:   return .orange
+        default:      return .blue
+        }
+    }
+
+    // MARK: - Image Loading
+
+    private func loadLogoImage(named logoName: String) -> UIImage? {
+        let supportDir = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let logoPath = supportDir
+            .appendingPathComponent("Logos", isDirectory: true)
+            .appendingPathComponent("\(logoName).png")
+
+        guard let data = try? Data(contentsOf: logoPath) else { return nil }
+        return UIImage(data: data)
+    }
+}

--- a/Supscription iOS/Views/Dashboard/UpcomingRenewalRow.swift
+++ b/Supscription iOS/Views/Dashboard/UpcomingRenewalRow.swift
@@ -17,6 +17,7 @@ struct UpcomingRenewalRow: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(subscription.accountName)
                     .font(.subheadline.weight(.medium))
+                    .lineLimit(1)
 
                 if let category = subscription.category,
                    !category.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -36,6 +37,9 @@ struct UpcomingRenewalRow: View {
             }
         }
         .padding(.vertical, 6)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(subscription.accountName)
+        .accessibilityValue(accessibilitySummary)
     }
 
     // MARK: - Logo / Icon
@@ -106,6 +110,20 @@ struct UpcomingRenewalRow: View {
         }
     }
 
+    private var accessibilitySummary: String {
+        let category = {
+            let trimmed = subscription.category?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (trimmed?.isEmpty ?? true) ? "Uncategorized" : trimmed!
+        }()
+        let price = subscription.price.formatted(.currency(code: Locale.current.currency?.identifier ?? "USD"))
+
+        if urgencyLabel.isEmpty {
+            return "\(category). \(price)."
+        }
+
+        return "\(category). \(price). Due \(urgencyLabel.lowercased())."
+    }
+
     // MARK: - Image Loading
 
     private func loadLogoImage(named logoName: String) -> UIImage? {
@@ -117,4 +135,10 @@ struct UpcomingRenewalRow: View {
         guard let data = try? Data(contentsOf: logoPath) else { return nil }
         return UIImage(data: data)
     }
+}
+
+#Preview("Upcoming Renewal Row") {
+    UpcomingRenewalRow(subscription: sampleSubscriptions[0])
+        .padding()
+        .background(Color(.systemBackground))
 }

--- a/Supscription iOS/Views/DashboardTab.swift
+++ b/Supscription iOS/Views/DashboardTab.swift
@@ -11,6 +11,7 @@ import Charts
 
 struct DashboardTab: View {
     @Query private var subscriptions: [Subscription]
+    @State private var showingAddSubscription = false
 
     var body: some View {
         NavigationStack {
@@ -25,23 +26,34 @@ struct DashboardTab: View {
             .navigationDestination(for: Subscription.self) { subscription in
                 SubscriptionDetailView(subscription: subscription)
             }
+            .fullScreenCover(isPresented: $showingAddSubscription) {
+                SubscriptionFormView(existingSubscriptions: subscriptions)
+            }
         }
     }
 
     // MARK: - Empty State
 
     private var emptyState: some View {
-        ContentUnavailableView(
-            "No Subscriptions Yet",
-            systemImage: "chart.bar.doc.horizontal",
-            description: Text("Add your first subscription to see spending insights, trends, and upcoming renewals.")
-        )
+        ContentUnavailableView {
+            Label("No Subscriptions Yet", systemImage: "chart.bar.doc.horizontal")
+        } description: {
+            Text("Add your first subscription to see spending insights, trends, and upcoming renewals.")
+        } actions: {
+            Button("Add Subscription") {
+                showingAddSubscription = true
+            }
+            .buttonStyle(.borderedProminent)
+        }
     }
 }
 
 // MARK: - Dashboard Content
 
 private struct DashboardContentView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.openURL) private var openURL
+
     let subscriptions: [Subscription]
 
     @StateObject private var viewModel: DashboardViewModel
@@ -55,11 +67,12 @@ private struct DashboardContentView: View {
         ScrollView {
             VStack(spacing: 20) {
                 scorecardsGrid
+                renewalsSection
                 monthlyTrendSection
                 categorySection
-                renewalsSection
             }
             .padding(.horizontal)
+            .padding(.top, 12)
             .padding(.bottom, 24)
         }
         .onChange(of: subscriptions) { _, newValue in
@@ -105,6 +118,7 @@ private struct DashboardContentView: View {
                 cardColor: .purple
             )
         }
+        .accessibilityElement(children: .contain)
     }
 
     // MARK: - Section 2: Monthly Trend
@@ -127,6 +141,11 @@ private struct DashboardContentView: View {
                     monthlyTrendChart
                         .frame(height: 180)
                         .padding(.top, 8)
+
+                    Text(viewModel.monthlyTrendAccessibilitySummary)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
                 } else {
                     Text("Add subscriptions with billing dates to see trends")
                         .font(.caption)
@@ -171,7 +190,7 @@ private struct DashboardContentView: View {
                     .foregroundStyle(.separator)
                 AxisValueLabel {
                     if let amount = value.as(Double.self) {
-                        Text("$\(Int(amount))")
+                        Text(viewModel.formattedAxisCurrency(amount))
                             .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
@@ -179,6 +198,8 @@ private struct DashboardContentView: View {
             }
         }
         .chartYScale(domain: 0...(viewModel.monthlySeries.map(\.amount).max() ?? 1) * 1.2)
+        .accessibilityLabel("Monthly spending trend")
+        .accessibilityValue(viewModel.monthlyTrendAccessibilitySummary)
     }
 
     // MARK: - Section 3: By Category
@@ -200,6 +221,13 @@ private struct DashboardContentView: View {
             } else {
                 categoryRows
                     .padding(.top, 8)
+
+                if let topCategory = viewModel.categoryBreakdown.first {
+                    Text("Top category: \(topCategory.category) at \(viewModel.formattedCurrency(topCategory.total)) per month.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .padding(.top, 4)
+                }
             }
         }
         .padding(16)
@@ -223,6 +251,9 @@ private struct DashboardContentView: View {
                             .font(.caption.weight(.bold))
                             .lineLimit(1)
                     }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(item.category)
+                    .accessibilityValue(viewModel.formattedCurrency(item.total))
 
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
@@ -306,6 +337,20 @@ private struct DashboardContentView: View {
                 }
                 .buttonStyle(.plain)
                 .padding(.horizontal, 16)
+                .contextMenu {
+                    Button(
+                        subscription.remindToCancel ? "Remove Reminder" : "Remind to Cancel",
+                        systemImage: subscription.remindToCancel ? "bell.slash" : "bell.badge"
+                    ) {
+                        toggleCancelReminder(for: subscription)
+                    }
+
+                    if subscription.accountURL?.isEmpty == false {
+                        Button("Open Website", systemImage: "safari") {
+                            openWebsite(for: subscription)
+                        }
+                    }
+                }
             }
 
             // Show More / Show Less
@@ -344,4 +389,56 @@ private struct DashboardContentView: View {
             .fill(.background)
             .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
     }
+
+    private func toggleCancelReminder(for subscription: Subscription) {
+        if subscription.remindToCancel {
+            subscription.remindToCancel = false
+            subscription.cancelReminderDate = nil
+        } else {
+            subscription.remindToCancel = true
+            subscription.cancelReminderDate = smartReminderDate(for: subscription)
+        }
+
+        try? modelContext.save()
+    }
+
+    private func smartReminderDate(for subscription: Subscription) -> Date {
+        let calendar = Calendar.current
+
+        guard let billingDate = subscription.billingDate,
+              let frequency = BillingFrequency(rawValue: subscription.billingFrequency),
+              frequency != .none else {
+            return calendar.date(byAdding: .day, value: 30, to: Date()) ?? Date()
+        }
+
+        let nextBilling = frequency.nextBillingDate(from: billingDate)
+        if let smartDate = calendar.date(byAdding: .day, value: -3, to: nextBilling),
+           smartDate > Date() {
+            return smartDate
+        }
+
+        return calendar.date(byAdding: .day, value: 30, to: Date()) ?? Date()
+    }
+
+    private func openWebsite(for subscription: Subscription) {
+        guard let urlString = subscription.accountURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !urlString.isEmpty else { return }
+
+        let normalized = urlString.hasPrefix("http://") || urlString.hasPrefix("https://")
+            ? urlString
+            : "https://\(urlString)"
+
+        guard let url = URL(string: normalized) else { return }
+        openURL(url)
+    }
+}
+
+#Preview("Dashboard Filled") {
+    DashboardTab()
+        .modelContainer(previewContainer)
+}
+
+#Preview("Dashboard Empty") {
+    DashboardTab()
+        .modelContainer(emptyPreviewContainer)
 }

--- a/Supscription iOS/Views/DashboardTab.swift
+++ b/Supscription iOS/Views/DashboardTab.swift
@@ -6,20 +6,342 @@
 //
 
 import SwiftUI
+import SwiftData
+import Charts
 
 struct DashboardTab: View {
+    @Query private var subscriptions: [Subscription]
+
     var body: some View {
         NavigationStack {
-            ContentUnavailableView(
-                "Dashboard",
-                systemImage: "chart.pie",
-                description: Text("Spending overview and upcoming renewals will appear here.")
-            )
+            Group {
+                if subscriptions.isEmpty {
+                    emptyState
+                } else {
+                    DashboardContentView(subscriptions: subscriptions)
+                }
+            }
             .navigationTitle("Dashboard")
+            .navigationDestination(for: Subscription.self) { subscription in
+                SubscriptionDetailView(subscription: subscription)
+            }
         }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No Subscriptions Yet",
+            systemImage: "chart.bar.doc.horizontal",
+            description: Text("Add your first subscription to see spending insights, trends, and upcoming renewals.")
+        )
     }
 }
 
-#Preview {
-    DashboardTab()
+// MARK: - Dashboard Content
+
+private struct DashboardContentView: View {
+    let subscriptions: [Subscription]
+
+    @StateObject private var viewModel: DashboardViewModel
+
+    init(subscriptions: [Subscription]) {
+        self.subscriptions = subscriptions
+        _viewModel = StateObject(wrappedValue: DashboardViewModel(subscriptions: subscriptions))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                scorecardsGrid
+                monthlyTrendSection
+                categorySection
+                renewalsSection
+            }
+            .padding(.horizontal)
+            .padding(.bottom, 24)
+        }
+        .onChange(of: subscriptions) { _, newValue in
+            viewModel.subscriptions = newValue
+        }
+    }
+
+    // MARK: - Section 1: Scorecards
+
+    private var scorecardsGrid: some View {
+        LazyVGrid(columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible(), spacing: 12)], spacing: 12) {
+            ScoreCardView(
+                title: "Monthly Spend",
+                value: viewModel.formattedCurrency(viewModel.monthlyTotal),
+                subtitle: "\(viewModel.activeCount) subscription\(viewModel.activeCount == 1 ? "" : "s")",
+                systemImage: "creditcard.fill",
+                cardColor: .blue
+            )
+
+            ScoreCardView(
+                title: "Yearly Spend",
+                value: viewModel.formattedCurrency(viewModel.yearlyTotal),
+                subtitle: "Projected total",
+                systemImage: "calendar",
+                cardColor: .orange
+            )
+
+            ScoreCardView(
+                title: "Due This Week",
+                value: "\(viewModel.dueSoonCount)",
+                subtitle: viewModel.dueSoonCount == 1 ? "Renewal upcoming" : "Renewals upcoming",
+                systemImage: "bell.fill",
+                cardColor: .green
+            )
+
+            ScoreCardView(
+                title: "Active Subs",
+                value: "\(viewModel.activeCount)",
+                subtitle: viewModel.remindToCancelCount > 0
+                    ? "\(viewModel.remindToCancelCount) flagged to cancel"
+                    : "All active",
+                systemImage: "square.grid.2x2.fill",
+                cardColor: .purple
+            )
+        }
+    }
+
+    // MARK: - Section 2: Monthly Trend
+
+    private var monthlyTrendSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionHeader("Spending")
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Monthly Trend")
+                    .font(.headline)
+
+                Text("Spending over 6 months")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                let hasSpend = viewModel.monthlySeries.contains { $0.amount > 0 }
+
+                if hasSpend {
+                    monthlyTrendChart
+                        .frame(height: 180)
+                        .padding(.top, 8)
+                } else {
+                    Text("Add subscriptions with billing dates to see trends")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .frame(maxWidth: .infinity, minHeight: 100)
+                }
+            }
+            .padding(16)
+            .background(cardBackground)
+        }
+    }
+
+    private var monthlyTrendChart: some View {
+        let seriesCount = viewModel.monthlySeries.count
+
+        return Chart(Array(viewModel.monthlySeries.enumerated()), id: \.element.id) { index, item in
+            let barOpacity = seriesCount > 1
+                ? 0.25 + 0.75 * (Double(index) / Double(seriesCount - 1))
+                : 1.0
+
+            BarMark(
+                x: .value("Month", item.month),
+                y: .value("Amount", item.amount)
+            )
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [Color.blue.opacity(barOpacity), Color.blue.opacity(barOpacity * 0.5)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .cornerRadius(4)
+        }
+        .chartXAxis {
+            AxisMarks { _ in
+                AxisValueLabel()
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading) { value in
+                AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5, dash: [4, 4]))
+                    .foregroundStyle(.separator)
+                AxisValueLabel {
+                    if let amount = value.as(Double.self) {
+                        Text("$\(Int(amount))")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .chartYScale(domain: 0...(viewModel.monthlySeries.map(\.amount).max() ?? 1) * 1.2)
+    }
+
+    // MARK: - Section 3: By Category
+
+    private var categorySection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("By Category")
+                .font(.headline)
+
+            Text("Monthly breakdown")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if viewModel.categoryBreakdown.isEmpty {
+                Text("No categories yet")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .frame(maxWidth: .infinity, minHeight: 60)
+            } else {
+                categoryRows
+                    .padding(.top, 8)
+            }
+        }
+        .padding(16)
+        .background(cardBackground)
+    }
+
+    private var categoryRows: some View {
+        let maxTotal = viewModel.categoryBreakdown.first?.total ?? 1
+        let rankColors: [Color] = [.blue, .purple, .orange, .teal, .gray]
+
+        return VStack(spacing: 10) {
+            ForEach(Array(viewModel.categoryBreakdown.enumerated()), id: \.element.id) { index, item in
+                VStack(spacing: 4) {
+                    HStack {
+                        Text(item.category)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                        Spacer()
+                        Text(viewModel.formattedCurrency(item.total))
+                            .font(.caption.weight(.bold))
+                            .lineLimit(1)
+                    }
+
+                    GeometryReader { geo in
+                        ZStack(alignment: .leading) {
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(.quaternary)
+                                .frame(height: 6)
+
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(rankColors[min(index, rankColors.count - 1)])
+                                .frame(
+                                    width: maxTotal > 0
+                                        ? geo.size.width * (item.total / maxTotal)
+                                        : 0,
+                                    height: 6
+                                )
+                        }
+                    }
+                    .frame(height: 6)
+                }
+            }
+        }
+    }
+
+    // MARK: - Section 4: Upcoming Renewals
+
+    private var renewalsSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            sectionHeader("Upcoming Renewals")
+
+            VStack(spacing: 0) {
+                // Header
+                HStack {
+                    Text("Next 30 Days")
+                        .font(.headline)
+                    Spacer()
+                    if !viewModel.upcomingRenewals.isEmpty {
+                        Text("\(viewModel.upcomingRenewals.count) total")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.top, 14)
+                .padding(.bottom, 10)
+
+                Divider()
+
+                if viewModel.upcomingRenewals.isEmpty {
+                    renewalsEmptyState
+                } else {
+                    renewalsList
+                }
+            }
+            .background(cardBackground)
+        }
+    }
+
+    private var renewalsEmptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.seal.fill")
+                .font(.largeTitle)
+                .foregroundStyle(.secondary)
+            Text("No renewals in the next 30 days")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var renewalsList: some View {
+        VStack(spacing: 0) {
+            ForEach(Array(viewModel.visibleRenewals.enumerated()), id: \.element.id) { index, subscription in
+                if index > 0 {
+                    Divider()
+                        .padding(.leading, 62)
+                }
+
+                NavigationLink(value: subscription) {
+                    UpcomingRenewalRow(subscription: subscription)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, 16)
+            }
+
+            // Show More / Show Less
+            if viewModel.upcomingRenewals.count > 5 {
+                Divider()
+                    .padding(.leading, 16)
+
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        viewModel.isExpanded.toggle()
+                    }
+                } label: {
+                    Text(viewModel.isExpanded
+                         ? "Show Less"
+                         : "Show All (\(viewModel.upcomingRenewals.count - 5) more)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                }
+            }
+        }
+    }
+
+    // MARK: - Shared Components
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .textCase(.uppercase)
+    }
+
+    private var cardBackground: some View {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+            .fill(.background)
+            .shadow(color: .black.opacity(0.06), radius: 4, y: 2)
+    }
 }

--- a/Supscription iOS/Views/SubscriptionDetailView.swift
+++ b/Supscription iOS/Views/SubscriptionDetailView.swift
@@ -59,7 +59,7 @@ struct SubscriptionDetailView: View {
                     }
                 }
                 Spacer()
-                Text(subscription.price, format: .currency(code: "USD"))
+                Text(subscription.price, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))
                     .font(.title3.weight(.semibold))
             }
             .padding(.vertical, 4)
@@ -178,4 +178,11 @@ struct SubscriptionDetailView: View {
         guard let data = try? Data(contentsOf: logoPath) else { return nil }
         return UIImage(data: data)
     }
+}
+
+#Preview {
+    NavigationStack {
+        SubscriptionDetailView(subscription: sampleSubscriptions[0])
+    }
+    .modelContainer(previewContainer)
 }

--- a/Supscription iOS/Views/SubscriptionsTab.swift
+++ b/Supscription iOS/Views/SubscriptionsTab.swift
@@ -122,7 +122,12 @@ struct SubscriptionsTab: View {
     }
 }
 
-#Preview {
+#Preview("Subscriptions Filled") {
     SubscriptionsTab()
         .modelContainer(previewContainer)
+}
+
+#Preview("Subscriptions Empty") {
+    SubscriptionsTab()
+        .modelContainer(emptyPreviewContainer)
 }

--- a/Supscription.xcodeproj/project.pbxproj
+++ b/Supscription.xcodeproj/project.pbxproj
@@ -30,6 +30,10 @@
 		1311220E2F84E61700922D01 /* PreviewContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131122052F84E61700922D01 /* PreviewContainer.swift */; };
 		1311220F2F84E61700922D01 /* DevFlags.swift in Sources */ = {isa = PBXBuildFile; fileRef = 131122032F84E61700922D01 /* DevFlags.swift */; };
 		133D167A2D29222600A3D7A8 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 133D16792D29222600A3D7A8 /* README.md */; };
+		1D439F46451A787042F44C9B /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D4161FF5B8C8C041F51245 /* DashboardViewModel.swift */; };
+		6808676872B919AAE84DBF44 /* Date+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F01262A337A1A12734B0EE /* Date+Formatting.swift */; };
+		7C35B57793017A865536BB40 /* Date+Formatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20F01262A337A1A12734B0EE /* Date+Formatting.swift */; };
+		CD28DCEC11D84BBA88C1F411 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29D4161FF5B8C8C041F51245 /* DashboardViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -74,6 +78,8 @@
 		133D16792D29222600A3D7A8 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		134F8A242D236E6B00198244 /* Supscription.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Supscription.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B6B8A22F6FA83B00604F29 /* SupscriptionTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SupscriptionTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		20F01262A337A1A12734B0EE /* Date+Formatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+Formatting.swift"; sourceTree = "<group>"; };
+		29D4161FF5B8C8C041F51245 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -166,6 +172,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01C098FDF88439C11FA10AE7 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				20F01262A337A1A12734B0EE /* Date+Formatting.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		1311204D2F82363000922D01 /* Models */ = {
 			isa = PBXGroup;
 			children = (
@@ -189,9 +203,11 @@
 		131120522F82363000922D01 /* Shared */ = {
 			isa = PBXGroup;
 			children = (
-				131122072F84E61700922D01 /* Utils */,
+				01C098FDF88439C11FA10AE7 /* Extensions */,
 				1311204D2F82363000922D01 /* Models */,
 				131120502F82363000922D01 /* Services */,
+				131122072F84E61700922D01 /* Utils */,
+				FB874E5A4BAFAD7D29A6EEDA /* ViewModels */,
 				131120512F82363000922D01 /* Secrets.plist */,
 			);
 			path = Shared;
@@ -232,6 +248,14 @@
 				13111D5F2F80E92B00922D01 /* Supscription iOSUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		FB874E5A4BAFAD7D29A6EEDA /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				29D4161FF5B8C8C041F51245 /* DashboardViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -449,6 +473,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1D439F46451A787042F44C9B /* DashboardViewModel.swift in Sources */,
+				7C35B57793017A865536BB40 /* Date+Formatting.swift in Sources */,
 				1311205B2F82363000922D01 /* SubscriptionManager.swift in Sources */,
 				1311205C2F82363000922D01 /* Subscription.swift in Sources */,
 				131122082F84E61700922D01 /* SeedData.swift in Sources */,
@@ -480,6 +506,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CD28DCEC11D84BBA88C1F411 /* DashboardViewModel.swift in Sources */,
+				6808676872B919AAE84DBF44 /* Date+Formatting.swift in Sources */,
 				131120542F82363000922D01 /* SubscriptionManager.swift in Sources */,
 				1311220C2F84E61700922D01 /* SeedData.swift in Sources */,
 				1311220D2F84E61700922D01 /* DummyData.swift in Sources */,

--- a/SupscriptionTests/BillingCalculationTests.swift
+++ b/SupscriptionTests/BillingCalculationTests.swift
@@ -338,6 +338,20 @@ final class BillingCalculationTests: XCTestCase {
         XCTAssertEqual(breakdown[2].category, "Cheap")
     }
 
+    func testCategoryBreakdown_groupsEmptyCategoriesAsUncategorized() {
+        let subs = [
+            makeSubscription(price: 10.0, billingFrequency: .monthly, category: nil),
+            makeSubscription(price: 15.0, billingFrequency: .monthly, category: "   ")
+        ]
+
+        let vm = DashboardViewModel(subscriptions: subs)
+        let breakdown = vm.categoryBreakdown
+
+        XCTAssertEqual(breakdown.count, 1)
+        XCTAssertEqual(breakdown[0].category, "Uncategorized")
+        XCTAssertEqual(breakdown[0].total, 25.0, accuracy: 0.01)
+    }
+
     // MARK: - Due Soon Count
 
     func testDueSoonCount_withinSevenDays() {
@@ -350,5 +364,40 @@ final class BillingCalculationTests: XCTestCase {
 
         let vm = DashboardViewModel(subscriptions: [sub1, sub2])
         XCTAssertEqual(vm.dueSoonCount, 1, "Only the subscription due in 3 days should count")
+    }
+
+    // MARK: - Upcoming Renewals
+
+    func testUpcomingRenewals_sortedAndLimitedToThirtyDays() {
+        let calendar = Calendar.current
+        let fiveDaysOut = calendar.date(byAdding: .day, value: 5, to: Date())!
+        let fifteenDaysOut = calendar.date(byAdding: .day, value: 15, to: Date())!
+        let fortyDaysOut = calendar.date(byAdding: .day, value: 40, to: Date())!
+
+        let late = makeSubscription(name: "Late", price: 10.0, billingFrequency: .monthly, billingDate: fifteenDaysOut)
+        let soon = makeSubscription(name: "Soon", price: 10.0, billingFrequency: .monthly, billingDate: fiveDaysOut)
+        let tooFar = makeSubscription(name: "Too Far", price: 10.0, billingFrequency: .monthly, billingDate: fortyDaysOut)
+
+        let vm = DashboardViewModel(subscriptions: [late, tooFar, soon])
+
+        XCTAssertEqual(vm.upcomingRenewals.map(\.accountName), ["Soon", "Late"])
+    }
+
+    func testVisibleRenewals_capsAtFiveUntilExpanded() {
+        let calendar = Calendar.current
+        let subscriptions = (1...6).map { index in
+            makeSubscription(
+                name: "Sub \(index)",
+                price: 10.0,
+                billingFrequency: .monthly,
+                billingDate: calendar.date(byAdding: .day, value: index, to: Date())!
+            )
+        }
+
+        let vm = DashboardViewModel(subscriptions: subscriptions)
+        XCTAssertEqual(vm.visibleRenewals.count, 5)
+
+        vm.isExpanded = true
+        XCTAssertEqual(vm.visibleRenewals.count, 6)
     }
 }

--- a/SupscriptionTests/BillingCalculationTests.swift
+++ b/SupscriptionTests/BillingCalculationTests.swift
@@ -158,19 +158,42 @@ final class BillingCalculationTests: XCTestCase {
 
     // MARK: - hasBillingEvent (via monthlySeries)
 
-    func testHasBillingEvent_monthlyAlwaysTrue() {
+    func testHasBillingEvent_monthlyStartsAtBillingMonth() {
         let calendar = Calendar.current
-        let billingDate = calendar.date(byAdding: .month, value: -6, to: Date())!
+        let billingDate = calendar.date(byAdding: .month, value: -2, to: Date())!
         let sub = makeSubscription(price: 10.0, billingFrequency: .monthly, billingDate: billingDate)
         let vm = DashboardViewModel(subscriptions: [sub])
 
-        // All 6 months should have the subscription's price
         let series = vm.monthlySeries
         XCTAssertEqual(series.count, 6)
-        for point in series {
-            XCTAssertEqual(point.amount, 10.0, accuracy: 0.01,
-                           "Monthly subscription should appear in every month, but \(point.month) had \(point.amount)")
+
+        let chargedMonths = series.filter { $0.amount > 0 }
+        XCTAssertEqual(chargedMonths.count, 3, "A subscription that started 2 months ago should only appear from its first billing month onward")
+
+        for point in series.prefix(3) {
+            XCTAssertEqual(point.amount, 0.0, accuracy: 0.01,
+                           "Months before the billing start should not show spend")
         }
+
+        for point in series.suffix(3) {
+            XCTAssertEqual(point.amount, 10.0, accuracy: 0.01,
+                           "Monthly subscriptions should charge once in each month after they start")
+        }
+    }
+
+    func testHasBillingEvent_weeklyCountsAllOccurrencesInMonth() {
+        let calendar = Calendar.current
+        let currentMonthStart = calendar.dateInterval(of: .month, for: Date())!.start
+        let billingDate = calendar.date(byAdding: .day, value: 1, to: currentMonthStart)!
+
+        let sub = makeSubscription(price: 10.0, billingFrequency: .weekly, billingDate: billingDate)
+        let vm = DashboardViewModel(subscriptions: [sub])
+
+        guard let currentMonthPoint = vm.monthlySeries.last else {
+            return XCTFail("Expected a data point for the current month")
+        }
+
+        XCTAssertGreaterThanOrEqual(currentMonthPoint.amount, 40.0, "Weekly subscriptions should count each weekly charge within the month")
     }
 
     func testHasBillingEvent_yearlyOnlyBillingMonth() {


### PR DESCRIPTION
## Summary
- improve the iOS dashboard structure for summary, insight, and light actions
- fix shared dashboard calculations for monthly trends and upcoming renewal behavior
- add filled and empty preview states for key iOS views used during dashboard work
- align iOS detail and dashboard formatting with localized currency display
- expand dashboard-related regression coverage in billing calculation tests

closes #50 