### PR TITLE
Feature/ios notifications

### DIFF
--- a/Shared/Services/NotificationService.swift
+++ b/Shared/Services/NotificationService.swift
@@ -5,19 +5,25 @@
 //  Created by Ricardo Flores on 4/20/25.
 //
 
+#if os(macOS)
 import AppKit
+#elseif os(iOS)
+import UIKit
+#endif
+
 import Foundation
 import UserNotifications
 
 final class NotificationService {
     static let shared = NotificationService()
     private init() {}
-    
+
     // MARK: - Request Permission
+
     func requestPermissionIfNeeded() async {
         let center = UNUserNotificationCenter.current()
         let settings = await center.notificationSettings()
-        
+
         switch settings.authorizationStatus {
         case .notDetermined:
             do {
@@ -30,27 +36,27 @@ final class NotificationService {
                 print("[Notifications] Failed to request permission: \(error.localizedDescription)")
                 #endif
             }
-            
+
         case .denied:
             #if DEBUG
             print("[Notifications] Notifications are denied. Suggest enabling in System Settings.")
             #endif
             await showNotificationSettingsAlert()
-            
+
         case .authorized:
             #if DEBUG
             print("[Notifications] Already authorized.")
             #endif
             return
-            
+
         case .provisional:
             #if DEBUG
-            print("[Notifications] Provisional authorization—used on iOS, but handled for completeness.")
+            print("[Notifications] Provisional authorization.")
             #endif
 
         case .ephemeral:
             #if DEBUG
-            print("[Notifications] Ephemeral authorization—used on iOS, but handled for completeness.")
+            print("[Notifications] Ephemeral authorization.")
             #endif
 
         @unknown default:
@@ -60,8 +66,10 @@ final class NotificationService {
             return
         }
     }
-    
-    // MARK: - Show alert to open system preferences
+
+    // MARK: - Platform-Specific Permission Alert
+
+    #if os(macOS)
     @MainActor
     private func showNotificationSettingsAlert() {
         let alert = NSAlert()
@@ -70,7 +78,7 @@ final class NotificationService {
         alert.alertStyle = .informational
         alert.addButton(withTitle: "Open Settings")
         alert.addButton(withTitle: "Cancel")
-        
+
         let response = alert.runModal()
         if response == .alertFirstButtonReturn {
             if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
@@ -78,11 +86,20 @@ final class NotificationService {
             }
         }
     }
-    
+    #elseif os(iOS)
+    @MainActor
+    private func showNotificationSettingsAlert() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+    #endif
+
     // MARK: - Schedule Notification
+
     func scheduleCancelReminder(for subscription: Subscription) {
         guard let reminderDate = subscription.cancelReminderDate else { return }
-        
+
         let now = Date()
         let normalizedDate = reminderDate.normalizedToMorning()
 
@@ -92,10 +109,9 @@ final class NotificationService {
         content.sound = .default
         content.userInfo = ["subscriptionID": subscription.id.uuidString]
         content.threadIdentifier = "cancelReminder"
-        content.summaryArgument = subscription.accountName
-        
+
         let trigger: UNNotificationTrigger
-        
+
         if normalizedDate <= now {
             // Fire in 10 seconds if selected date is now or in the past
             #if DEBUG
@@ -110,7 +126,7 @@ final class NotificationService {
             #endif
             trigger = UNCalendarNotificationTrigger(dateMatching: triggerDateComponents, repeats: false)
         }
-        
+
         let request = UNNotificationRequest(
             identifier: "cancelReminder_\(subscription.id.uuidString)",
             content: content,
@@ -127,8 +143,9 @@ final class NotificationService {
             #endif
         }
     }
-    
+
     // MARK: - Remove Notification
+
     func removeNotification(for subscription: Subscription) {
         let identifier = "cancelReminder_\(subscription.id.uuidString)"
         UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
@@ -136,15 +153,34 @@ final class NotificationService {
         print("[Notifications] Removed notification for \(subscription.accountName)")
         #endif
     }
-    
+
+    // MARK: - Remove All Cancel Reminders
+
+    func removeAllCancelReminders() {
+        let center = UNUserNotificationCenter.current()
+        center.getPendingNotificationRequests { requests in
+            let cancelIDs = requests
+                .filter { $0.identifier.hasPrefix("cancelReminder_") }
+                .map(\.identifier)
+            if !cancelIDs.isEmpty {
+                center.removePendingNotificationRequests(withIdentifiers: cancelIDs)
+                #if DEBUG
+                print("[Notifications] Removed \(cancelIDs.count) cancel reminder(s)")
+                #endif
+            }
+        }
+    }
+
     // MARK: - Dynamic Body Text
+
     private func notificationBody(for subscription: Subscription) -> String {
         let date = subscription.cancelReminderDate ?? Date()
         let relativeString = date.formatted(.relative(presentation: .named))
         return "You planned to cancel \(subscription.accountName) \(relativeString)."
     }
-    
+
     // MARK: - Testing
+
     #if DEBUG
     func scheduleTestNotification() {
         let content = UNMutableNotificationContent()

--- a/Shared/Services/NotificationService.swift
+++ b/Shared/Services/NotificationService.swift
@@ -98,6 +98,14 @@ final class NotificationService {
     // MARK: - Schedule Notification
 
     func scheduleCancelReminder(for subscription: Subscription) {
+        let remindersEnabled = UserDefaults.standard.object(forKey: AppSettingKey.cancelRemindersEnabled) as? Bool ?? true
+        guard remindersEnabled else {
+            #if DEBUG
+            print("[Notifications] Cancel reminders disabled in Settings — skipping schedule for \(subscription.accountName)")
+            #endif
+            return
+        }
+
         guard let reminderDate = subscription.cancelReminderDate else { return }
 
         let now = Date()

--- a/Supscription iOS/Views/DashboardTab.swift
+++ b/Supscription iOS/Views/DashboardTab.swift
@@ -394,9 +394,14 @@ private struct DashboardContentView: View {
         if subscription.remindToCancel {
             subscription.remindToCancel = false
             subscription.cancelReminderDate = nil
+            NotificationService.shared.removeNotification(for: subscription)
         } else {
             subscription.remindToCancel = true
             subscription.cancelReminderDate = smartReminderDate(for: subscription)
+            Task {
+                await NotificationService.shared.requestPermissionIfNeeded()
+                NotificationService.shared.scheduleCancelReminder(for: subscription)
+            }
         }
 
         try? modelContext.save()

--- a/Supscription iOS/Views/SettingsTab.swift
+++ b/Supscription iOS/Views/SettingsTab.swift
@@ -6,8 +6,10 @@
 //
 
 import SwiftUI
+import SwiftData
 
 struct SettingsTab: View {
+    @Query private var subscriptions: [Subscription]
     @AppStorage(AppSettingKey.preferredAppearanceMode)
     private var appearanceMode: String = AppSettingDefault.preferredAppearanceMode
 
@@ -78,6 +80,18 @@ struct SettingsTab: View {
         Section {
             Toggle("Billing Reminders", isOn: $billingRemindersEnabled)
             Toggle("Cancel Reminders", isOn: $cancelRemindersEnabled)
+                .onChange(of: cancelRemindersEnabled) { _, newValue in
+                    if newValue {
+                        Task {
+                            await NotificationService.shared.requestPermissionIfNeeded()
+                            for subscription in subscriptions where subscription.remindToCancel {
+                                NotificationService.shared.scheduleCancelReminder(for: subscription)
+                            }
+                        }
+                    } else {
+                        NotificationService.shared.removeAllCancelReminders()
+                    }
+                }
         } header: {
             Text("Notifications")
         } footer: {

--- a/Supscription iOS/Views/SubscriptionDetailView.swift
+++ b/Supscription iOS/Views/SubscriptionDetailView.swift
@@ -128,14 +128,14 @@ struct SubscriptionDetailView: View {
                 }
             }
         }
-        .confirmationDialog(
+        .alert(
             "Delete \"\(subscription.accountName)\"?",
-            isPresented: $showingDeleteConfirmation,
-            titleVisibility: .visible
+            isPresented: $showingDeleteConfirmation
         ) {
             Button("Delete", role: .destructive) {
                 deleteSubscription()
             }
+            Button("Cancel", role: .cancel) { }
         } message: {
             Text("This action cannot be undone.")
         }

--- a/Supscription iOS/Views/SubscriptionDetailView.swift
+++ b/Supscription iOS/Views/SubscriptionDetailView.swift
@@ -142,6 +142,8 @@ struct SubscriptionDetailView: View {
     }
 
     private func deleteSubscription() {
+        NotificationService.shared.removeNotification(for: subscription)
+
         if subscription.logoName != nil {
             LogoFetchService.shared.deleteLogo(for: subscription)
         }

--- a/Supscription iOS/Views/SubscriptionFormView.swift
+++ b/Supscription iOS/Views/SubscriptionFormView.swift
@@ -158,6 +158,7 @@ struct SubscriptionFormView: View {
             Toggle("Remind to Cancel", isOn: $remindToCancel)
                 .onChange(of: remindToCancel) { _, newValue in
                     guard newValue else { return }
+                    Task { await NotificationService.shared.requestPermissionIfNeeded() }
                     if isEditing, subscriptionToEdit?.cancelReminderDate != nil { return }
                     setSmartReminderDate()
                 }
@@ -259,6 +260,13 @@ struct SubscriptionFormView: View {
 
         try? modelContext.save()
 
+        // Handle notifications
+        if remindToCancel {
+            NotificationService.shared.scheduleCancelReminder(for: subscription)
+        } else {
+            NotificationService.shared.removeNotification(for: subscription)
+        }
+
         if subscription.logoName == nil {
             Task {
                 await LogoFetchService.shared.fetchLogo(for: subscription, in: modelContext)
@@ -285,6 +293,11 @@ struct SubscriptionFormView: View {
 
         modelContext.insert(newSubscription)
         try? modelContext.save()
+
+        // Handle notifications
+        if remindToCancel {
+            NotificationService.shared.scheduleCancelReminder(for: newSubscription)
+        }
 
         Task {
             await LogoFetchService.shared.fetchLogo(for: newSubscription, in: modelContext)

--- a/Supscription iOS/Views/SubscriptionsTab.swift
+++ b/Supscription iOS/Views/SubscriptionsTab.swift
@@ -12,11 +12,16 @@ enum SortOption: String, CaseIterable {
     case name = "Name"
     case price = "Price"
     case billingDate = "Billing Date"
+    case dateAdded = "Recently Added"
 }
 
 struct SubscriptionsTab: View {
+    @Environment(\.modelContext) private var modelContext
     @Query(sort: \Subscription.accountName) private var subscriptions: [Subscription]
     @State private var showingAddSubscription = false
+    @State private var subscriptionToEdit: Subscription? = nil
+    @State private var subscriptionToDelete: Subscription? = nil
+    @State private var showDeleteConfirmation = false
     @State private var searchText = ""
     @AppStorage("selectedSort") private var selectedSort: SortOption = .name
     @AppStorage("sortAscending") private var sortAscending: Bool = true
@@ -42,6 +47,8 @@ struct SubscriptionsTab: View {
                 let rhs = $1.billingDate ?? .distantFuture
                 return sortAscending ? lhs < rhs : lhs > rhs
             }
+        case .dateAdded:
+            result.sort { sortAscending ? $0.lastModified < $1.lastModified : $0.lastModified > $1.lastModified }
         }
 
         return result
@@ -53,6 +60,66 @@ struct SubscriptionsTab: View {
                 NavigationLink(value: subscription) {
                     SubscriptionRow(subscription: subscription)
                 }
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button(role: .destructive) {
+                        subscriptionToDelete = subscription
+                        showDeleteConfirmation = true
+                    } label: {
+                        Label("Delete", systemImage: "trash")
+                    }
+                }
+                .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                    Button {
+                        toggleReminder(for: subscription)
+                    } label: {
+                        Label(
+                            subscription.remindToCancel ? "Remove Reminder" : "Remind to Cancel",
+                            systemImage: subscription.remindToCancel ? "bell.slash" : "bell.badge"
+                        )
+                    }
+                    .tint(subscription.remindToCancel ? .orange : .teal)
+                }
+                .contextMenu {
+                    Button("Edit", systemImage: "pencil") {
+                        subscriptionToEdit = subscription
+                    }
+
+                    Button(
+                        subscription.remindToCancel ? "Remove Reminder" : "Remind to Cancel",
+                        systemImage: subscription.remindToCancel ? "bell.slash" : "bell.badge"
+                    ) {
+                        toggleReminder(for: subscription)
+                    }
+
+                    Divider()
+
+                    Button("Delete", systemImage: "trash", role: .destructive) {
+                        subscriptionToDelete = subscription
+                        showDeleteConfirmation = true
+                    }
+                }
+            }
+            .fullScreenCover(item: $subscriptionToEdit) { subscription in
+                SubscriptionFormView(
+                    subscriptionToEdit: subscription,
+                    existingSubscriptions: subscriptions
+                )
+            }
+            .alert(
+                "Delete \"\(subscriptionToDelete?.accountName ?? "")\"?",
+                isPresented: $showDeleteConfirmation
+            ) {
+                Button("Delete", role: .destructive) {
+                    if let subscription = subscriptionToDelete {
+                        delete(subscription)
+                    }
+                    subscriptionToDelete = nil
+                }
+                Button("Cancel", role: .cancel) {
+                    subscriptionToDelete = nil
+                }
+            } message: {
+                Text("This action cannot be undone.")
             }
             .navigationTitle("Subscriptions")
             .navigationDestination(for: Subscription.self) { subscription in
@@ -78,7 +145,8 @@ struct SubscriptionsTab: View {
                                             sortAscending.toggle()
                                         } else {
                                             selectedSort = option
-                                            sortAscending = true
+                                            // Recently Added defaults to newest first (descending)
+                                            sortAscending = option == .dateAdded ? false : true
                                         }
                                     }
                                 )) {
@@ -115,10 +183,52 @@ struct SubscriptionsTab: View {
                     ContentUnavailableView.search(text: searchText)
                 }
             }
-            .fullScreenCover(isPresented: $showingAddSubscription) {
-                SubscriptionFormView(existingSubscriptions: subscriptions.map { $0 })
+        }
+        .fullScreenCover(isPresented: $showingAddSubscription) {
+            SubscriptionFormView(existingSubscriptions: subscriptions.map { $0 })
+        }
+    }
+
+    // MARK: - Actions
+
+    private func delete(_ subscription: Subscription) {
+        NotificationService.shared.removeNotification(for: subscription)
+        if subscription.logoName != nil {
+            LogoFetchService.shared.deleteLogo(for: subscription)
+        }
+        modelContext.delete(subscription)
+        try? modelContext.save()
+    }
+
+    private func toggleReminder(for subscription: Subscription) {
+        if subscription.remindToCancel {
+            subscription.remindToCancel = false
+            subscription.cancelReminderDate = nil
+            NotificationService.shared.removeNotification(for: subscription)
+        } else {
+            subscription.remindToCancel = true
+            subscription.cancelReminderDate = smartReminderDate(for: subscription)
+            Task {
+                await NotificationService.shared.requestPermissionIfNeeded()
+                NotificationService.shared.scheduleCancelReminder(for: subscription)
             }
         }
+        try? modelContext.save()
+    }
+
+    private func smartReminderDate(for subscription: Subscription) -> Date {
+        let calendar = Calendar.current
+        guard let billingDate = subscription.billingDate,
+              let frequency = BillingFrequency(rawValue: subscription.billingFrequency),
+              frequency != .none else {
+            return calendar.date(byAdding: .day, value: 30, to: Date()) ?? Date()
+        }
+        let nextBilling = frequency.nextBillingDate(from: billingDate)
+        if let smartDate = calendar.date(byAdding: .day, value: -3, to: nextBilling),
+           smartDate > Date() {
+            return smartDate
+        }
+        return calendar.date(byAdding: .day, value: 30, to: Date()) ?? Date()
     }
 }
 

--- a/Supscription.xcodeproj/project.pbxproj
+++ b/Supscription.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C535C107BA33190CE9B3410 /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D163FAE2FC4ACF69BF094F14 /* NotificationService.swift */; };
+		102AF19327DB23E450A5ED3E /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D163FAE2FC4ACF69BF094F14 /* NotificationService.swift */; };
 		131120532F82363000922D01 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 131120512F82363000922D01 /* Secrets.plist */; };
 		131120542F82363000922D01 /* SubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1311204B2F82363000922D01 /* SubscriptionManager.swift */; };
 		131120552F82363000922D01 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1311204A2F82363000922D01 /* Subscription.swift */; };
@@ -61,6 +63,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D163FAE2FC4ACF69BF094F14 /* NotificationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationService.swift; sourceTree = "<group>"; };
 		13111D452F80E92900922D01 /* Supscription iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Supscription iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13111D552F80E92B00922D01 /* Supscription iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Supscription iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13111D5F2F80E92B00922D01 /* Supscription iOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Supscription iOSUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -196,6 +199,7 @@
 			children = (
 				1311204E2F82363000922D01 /* CategorySuggestionService.swift */,
 				1311204F2F82363000922D01 /* LogoFetchService.swift */,
+				D163FAE2FC4ACF69BF094F14 /* NotificationService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -473,6 +477,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				102AF19327DB23E450A5ED3E /* NotificationService.swift in Sources */,
 				1D439F46451A787042F44C9B /* DashboardViewModel.swift in Sources */,
 				7C35B57793017A865536BB40 /* Date+Formatting.swift in Sources */,
 				1311205B2F82363000922D01 /* SubscriptionManager.swift in Sources */,
@@ -506,6 +511,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1C535C107BA33190CE9B3410 /* NotificationService.swift in Sources */,
 				CD28DCEC11D84BBA88C1F411 /* DashboardViewModel.swift in Sources */,
 				6808676872B919AAE84DBF44 /* Date+Formatting.swift in Sources */,
 				131120542F82363000922D01 /* SubscriptionManager.swift in Sources */,


### PR DESCRIPTION
- Moves NotificationService to Shared/ with cross-platform #if os() guards, then wires the full notification lifecycle into the iOS app.
- Notification scheduling wired into all iOS flows: create, edit, delete, and Dashboard reminder context menu
- Permission prompt fires the moment the "Remind to Cancel" toggle is flipped on — not deferred to save
- Cancel Reminders toggle in Settings now has real behavior: off removes all pending notifications immediately, on re-schedules every subscription with reminders enabled

Closes #64 